### PR TITLE
travis-ci build status links to the wrong project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Uses [cheeaun's](http://cheeaun.com/) [node-hnapi](https://github.com/cheeaun/no
 
 Building
 ---
-[![Build Status](https://travis-ci.org/dinosaurwithakatana/holo_hacker_news.svg?branch=master)](https://travis-ci.org/dinosaurwithakatana/holo_hacker_news) 
+[![Build Status](https://travis-ci.org/dinosaurwithakatana/hacker-news-android.svg?branch=master)](https://travis-ci.org/dinosaurwithakatana/holo_hacker_news) 
 
 Copy each of the `*.properties.example` to their respective properties files and fill out as necessary.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Uses [cheeaun's](http://cheeaun.com/) [node-hnapi](https://github.com/cheeaun/no
 
 Building
 ---
-[![Build Status](https://travis-ci.org/dinosaurwithakatana/hacker-news-android.svg?branch=master)](https://travis-ci.org/dinosaurwithakatana/holo_hacker_news) 
+[![Build Status](https://travis-ci.org/dinosaurwithakatana/hacker-news-android.svg?branch=master)](https://travis-ci.org/dinosaurwithakatana/hacker-news-android) 
 
 Copy each of the `*.properties.example` to their respective properties files and fill out as necessary.
 


### PR DESCRIPTION
Resolves issue #39

It links to the old holo-hacker-news project name.

I simply redid the link in the README.  There's two commits because I missed one of the links.