### PR TITLE
added comments font size option

### DIFF
--- a/app/src/main/java/io/dwak/holohackernews/app/preferences/UserPreferenceManager.java
+++ b/app/src/main/java/io/dwak/holohackernews/app/preferences/UserPreferenceManager.java
@@ -14,6 +14,7 @@ public class UserPreferenceManager {
     public static final String PREF_LINK_FIRST = "pref_link_first";
     public static final String PREF_LIST_ANIMATIONS = "pref_list_animations";
     public static final String PREF_NIGHT_MODE = "pref_night_mode";
+    public static final String PREF_TEXT_SIZE = "pref_text_size";
 
     public static void useExternalBrowser(@NonNull final Context context, final boolean shouldUseSystemBrowser){
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
@@ -23,6 +24,11 @@ public class UserPreferenceManager {
     public static boolean showLinkFirst(@NonNull final Context context){
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
         return sp.getBoolean(PREF_LINK_FIRST, false);
+    }
+
+    public static String preferredTextSize(@NonNull final Context context){
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
+        return sp.getString(PREF_TEXT_SIZE, "small");
     }
 
     public static boolean isExternalBrowserEnabled(@NonNull final Context context){

--- a/app/src/main/java/io/dwak/holohackernews/app/ui/storydetail/CommentViewHolder.java
+++ b/app/src/main/java/io/dwak/holohackernews/app/ui/storydetail/CommentViewHolder.java
@@ -7,6 +7,7 @@ import android.support.v7.widget.RecyclerView;
 import android.text.Html;
 import android.text.Spanned;
 import android.text.method.LinkMovementMethod;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.FrameLayout;
@@ -57,6 +58,22 @@ class CommentViewHolder extends RecyclerView.ViewHolder implements View.OnClickL
         final Spanned commentContent = Html.fromHtml(comment.getContent());
         viewHolder.mCommentContent.setMovementMethod(LinkMovementMethod.getInstance());
         viewHolder.mCommentContent.setText(commentContent);
+
+        //set comment text size
+        String textSize = UserPreferenceManager.preferredTextSize(context);
+        if(textSize.equals(context.getString(R.string.pref_text_size_small))) {
+            viewHolder.mCommentContent.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14);
+            viewHolder.mCommentSubmitter.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14);
+        }
+        else if(textSize.equals(context.getString(R.string.pref_text_size_medium))) {
+            viewHolder.mCommentContent.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 16);
+            viewHolder.mCommentSubmitter.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14);
+        }
+        else {
+            viewHolder.mCommentContent.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 18);
+            viewHolder.mCommentSubmitter.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 16);
+        }
+
         if (hiddenChildrenCount == 0) {
             viewHolder.mHiddenCommentCount.setVisibility(View.GONE);
         }

--- a/app/src/main/java/io/dwak/holohackernews/app/ui/storydetail/CommentsListAdapter.java
+++ b/app/src/main/java/io/dwak/holohackernews/app/ui/storydetail/CommentsListAdapter.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.text.Html;
 import android.text.Spanned;
 import android.text.method.LinkMovementMethod;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -75,6 +76,7 @@ public class CommentsListAdapter extends ArrayAdapter<Comment> {
         final Spanned commentContent = Html.fromHtml(getItem(position).getContent());
         viewHolder.mCommentContent.setMovementMethod(LinkMovementMethod.getInstance());
         viewHolder.mCommentContent.setText(commentContent);
+        viewHolder.mCommentContent.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 12);
         viewHolder.mCommentSubmissionTime.setText(getItem(position).getTimeAgo());
         viewHolder.mOverflow.setOnClickListener(view -> commentAction(position));
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="textSizeEntries">
+        <item>Small</item>
+        <item>Medium</item>
+        <item>Large</item>
+    </string-array>
+    <string-array name="textSizeValues">
+        <item>@string/pref_text_size_small</item>
+        <item>@string/pref_text_size_medium</item>
+        <item>@string/pref_text_size_large</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,4 +54,8 @@
     <string name="complete">Complete</string>
     <string name="logout">Logout</string>
     <string name="pref_night_mode_title">Night Mode</string>
+    <string name="text_size">Text size</string>
+    <string name="pref_text_size_small">small</string>
+    <string name="pref_text_size_medium">medium</string>
+    <string name="pref_text_size_large">large</string>
 </resources>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -14,4 +14,12 @@
         android:key="pref_night_mode"
         android:title="@string/pref_night_mode_title"
         android:defaultValue="false" />
+
+    <ListPreference
+        android:key="pref_text_size"
+        android:title="@string/text_size"
+        android:entries="@array/textSizeEntries"
+        android:entryValues="@array/textSizeValues"
+        android:defaultValue="@string/pref_text_size_small"/>
+
 </PreferenceScreen>


### PR DESCRIPTION
Added a setting to switch comments font sizes.

SettingsActivity:
<img src="https://cloud.githubusercontent.com/assets/7422005/6864055/21e2d692-d419-11e4-9fae-3628ede47bd6.png" width="200">

ListPreference:
<img src="https://cloud.githubusercontent.com/assets/7422005/6864056/2493f812-d419-11e4-945a-2c3aaf881463.png" width="200">

Small (default):
<img src="https://cloud.githubusercontent.com/assets/7422005/6864066/48b8b336-d419-11e4-9cbf-25ef7d87b020.png" width="300">

Medium:
<img src="https://cloud.githubusercontent.com/assets/7422005/6864068/4aed1674-d419-11e4-811a-9b187be151e4.png" width="300">

Large:
<img src="https://cloud.githubusercontent.com/assets/7422005/6864069/4c6a2dac-d419-11e4-94e2-473ff4d8e019.png" width="300">

