### PR TITLE
fixes drawer position not updating on rotation

### DIFF
--- a/app/src/main/java/io/dwak/holohackernews/app/ui/storydetail/StoryDetailFragment.java
+++ b/app/src/main/java/io/dwak/holohackernews/app/ui/storydetail/StoryDetailFragment.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.graphics.Point;
 import android.net.Uri;
 import android.os.Bundle;
@@ -135,14 +136,12 @@ public class StoryDetailFragment extends BaseFragment implements ObservableWebVi
                 mLinkLayout.setOpen(!mLinkLayout.isOpen());
                 if ("ask".equals(mStoryDetail.getType())) {
                     mStoryDetail.setUrl(HACKER_NEWS_BASE_URL + mStoryDetail.getUrl());
-                }
-                else if ("job".equals(mStoryDetail.getType())) {
+                } else if ("job".equals(mStoryDetail.getType())) {
                     if (mStoryDetail.getUrl().contains("/item?id=")) {
                         mStoryDetail.setUrl(HACKER_NEWS_BASE_URL + mStoryDetail.getUrl());
                     }
                 }
-            }
-            else {
+            } else {
                 openLinkInExternalBrowser();
             }
         });
@@ -373,15 +372,27 @@ public class StoryDetailFragment extends BaseFragment implements ObservableWebVi
         return super.onOptionsItemSelected(item);
     }
 
-    private void setupWebViewDrawer() {
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        updateWebViewDrawerPosition();
+
+    }
+
+    private void updateWebViewDrawerPosition(){
         Display display = getActivity().getWindowManager().getDefaultDisplay();
         Point size = new Point();
         display.getSize(size);
         int width = size.x;
         int height = size.y;
-
         mLinkLayout.setStashPixel(height);
         mLinkLayout.setRevealPixel(0);
+        mLinkLayout.updateListener();
+        mLinkLayout.setOpen(mLinkLayout.isOpen());
+    }
+
+    private void setupWebViewDrawer() {
+        updateWebViewDrawerPosition();
         mLinkLayout.setTranslateDirection(ReboundRevealRelativeLayout.TRANSLATE_DIRECTION_VERTICAL);
         if (!UserPreferenceManager.isExternalBrowserEnabled(getActivity())) {
             mLinkLayout.setOpen(mWasLinkLayoutOpen || (UserPreferenceManager.showLinkFirst(getActivity())));

--- a/app/src/main/java/io/dwak/holohackernews/app/widget/ReboundRevealRelativeLayout.java
+++ b/app/src/main/java/io/dwak/holohackernews/app/widget/ReboundRevealRelativeLayout.java
@@ -40,12 +40,15 @@ public class ReboundRevealRelativeLayout extends RelativeLayout {
         SpringSystem springSystem = SpringSystem.create();
         mSpring = springSystem.createSpring();
         mSpring.setSpringConfig(SPRING_CONFIG);
+        updateListener();
+    }
+
+    public void updateListener(){
         LinkSpringListener linkSpringListener = new LinkSpringListener();
         mSpring.setCurrentValue(0)
                 .setEndValue(1)
                 .addListener(linkSpringListener);
     }
-
     /**
      * Set whether the view visible or not
      *


### PR DESCRIPTION
fixes #34 

because the app has  [`android:configChanges`](https://github.com/dinosaurwithakatana/hacker-news-android/blob/master/app/src/main/AndroidManifest.xml#L29) set, activities and fragments are not being restarted normally. 

So if the user was to open StoryDetailFragment while on landscape, [`display.getSize()`](https://github.com/dinosaurwithakatana/hacker-news-android/blob/master/app/src/main/java/io/dwak/holohackernews/app/ui/storydetail/StoryDetailFragment.java#L378-L383) would return the height of the screen while on landscape. This value is then passed as the ["stashedPixel"](https://github.com/dinosaurwithakatana/hacker-news-android/blob/master/app/src/main/java/io/dwak/holohackernews/app/ui/storydetail/StoryDetailFragment.java#L378-L383) to the rebound layout, making it the pixel the drawer will be set when the webview is hidden. 

Then, if the user rotates to portrait, the fragment state is retained, and stashedPixel value will be the same. Because landscape height < portrait height, the drawer is set what seems to be in the middle of the screen. 

So the solution is to catch rotations in the fragment manually and update the layout's stashedPixel value and listener.
